### PR TITLE
Added support for UNNotificationRequest

### DIFF
--- a/local-notifications-common.js
+++ b/local-notifications-common.js
@@ -5,7 +5,8 @@ LocalNotifications.defaults = {
   title: '',
   body: '',
   badge: 0,
-  interval: 0
+  repeats: 0,
+  trigger: ''
 };
 
 LocalNotifications.merge = function merge(obj1, obj2) { // Our merge function


### PR DESCRIPTION
Removed the interval option and replaced it with repeats which acts as a boolean, and you can now choose the triggertype by defining trigger : 'timeinterval'. Defaults to UNCalendarNotificationTrigger. if timeinterval is chosen, the at parameter will have to be amount of seconds from the scheduling time until the notification should appear