### PR TITLE
Ios10

### DIFF
--- a/local-notifications-common.js
+++ b/local-notifications-common.js
@@ -5,7 +5,8 @@ LocalNotifications.defaults = {
   title: '',
   body: '',
   badge: 0,
-  interval: 0
+  repeat: 0,
+  trigger: '' // Defaults to UNCalendarNotificationTrigger unless if its set to 'timeinterval'
 };
 
 LocalNotifications.merge = function merge(obj1, obj2) { // Our merge function


### PR DESCRIPTION
Rewritten to work with the new iOS10 UNNotificationCenter. 
To enable the application to show and handle notifications while in the foreground, the following will have to be added to the app.js file:

```
if (application.ios) {

    var __extends = this.__extends || function (d, b) {
        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
        function __() { this.constructor = d; }
        __.prototype = b.prototype;
        d.prototype = new __();
    };

    var appDelegate = (function (_super ) {

        __extends(appDelegate, _super);

        function appDelegate() {
            _super.apply(this, arguments);
        }

        appDelegate.prototype.userNotificationCenterDidReceiveNotificationResponseWithCompletionHandler = function(center, notif, completion){
            completion();
        }

        appDelegate.prototype.userNotificationCenterWillPresentNotificationWithCompletionHandler = function(center, notif, completion){
            completion(4);  // 4 is equal to UNNotificationPresentationOptions.Alert
        }    

        appDelegate.prototype.applicationDidFinishLaunchingWithOptions = function (application, launchOptions) {

            // Assign the delegate to UNUserNotificationCenter. This allows the application to receive notifications while in foreground
            var center = utils.ios.getter(UNUserNotificationCenter, UNUserNotificationCenter.currentNotificationCenter);
            center.delegate = this; 

        };

        appDelegate.ObjCProtocols = [UIApplicationDelegate, UNUserNotificationCenterDelegate];
        return appDelegate;

    })(UIResponder);

    application.ios.delegate = appDelegate;

}
```
