### PR TITLE
Added onGoing notification (cannot be dismissed by user)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Note that after a reboot the `smallIcon` and `largeIcon` are not restored but fa
     body: 'Recurs every minute until cancelled',
     ticker: 'The ticker',
     badge: 1,
-    onGoing: true //makes the notification ongoing (Android only)
+    onGoing: true, //makes the notification ongoing (Android only)
     smallIcon: 'res://heart.png',
     interval: 'minute',
     sound: null, // suppress the default sound

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You can pass several options to this function, everything is optional:
 |`interval` |Set to one of `second minute hour day week month quarter year` if you want a recurring notification.|
 |`smallIcon` |On Android you can set a custom icon in the system tray. Pass in 'res://filename.png' which lives in App_Resouces/Android/drawable folders. If not passed, we look for a file named 'ic_stat_notify.png' in the App_Resources/Android/drawable folders. Default: the app icon.|
 |`largeIcon` |Same as `smallIcon`, but this one is shown when you expand the notification center. The optional file we look for is not 'ic_stat_notify.png' but 'ic_notify.png'.|
+| `onGoing` |Default is (`false`). Set whether this is an `ongoing` notification. Ongoing notifications cannot be dismissed by the user, so your application or service must take care of canceling them.(**Android Only**) |
 
 Note that after a reboot the `smallIcon` and `largeIcon` are not restored but fall back to the default (app icon). This is a known issue and can be fixed in a future version.
 
@@ -61,6 +62,7 @@ Note that after a reboot the `smallIcon` and `largeIcon` are not restored but fa
     body: 'Recurs every minute until cancelled',
     ticker: 'The ticker',
     badge: 1,
+    onGoing: true //makes the notification ongoing (Android only)
     smallIcon: 'res://heart.png',
     interval: 'minute',
     sound: null, // suppress the default sound

--- a/local-notifications-common.js
+++ b/local-notifications-common.js
@@ -5,7 +5,8 @@ LocalNotifications.defaults = {
   title: '',
   body: '',
   badge: 0,
-  interval: 0
+  interval: 0,
+  onGoing: false
 };
 
 LocalNotifications.merge = function merge(obj1, obj2) { // Our merge function

--- a/local-notifications.android.js
+++ b/local-notifications.android.js
@@ -75,6 +75,7 @@ LocalNotifications.schedule = function (arg) {
             .setAutoCancel(true) // removes the notification from the statusbar once tapped
             .setSound(options.sound === null ? null : android.net.Uri.parse(options.sound))
             .setNumber(options.badge)
+            .setOngoing(options.onGoing)//sets the notification to ongoing if its true.
             .setTicker(options.ticker || options.body);
 
         // add the intent that handles the event when the notification is clicked (which should launch the app)


### PR DESCRIPTION
Hi Eddy, 

I added onGoing as an option for the notification. see [here](https://developer.android.com/reference/android/app/Notification.Builder.html#setOngoing(boolean)) for more details. I could only implement this for android, not sure it's currently possible for ios.