### PR TITLE
builder.channelId is defined in 26.1, fixes #66

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -15,5 +15,5 @@ repositories {
 
 dependencies {
     // Android 8 requires us to set a channel, which is supported since support-v4 version 26
-    compile "com.android.support:support-v4:26+"
+    compile "com.android.support:support-v4:26.1+"
 }


### PR DESCRIPTION
Kudos to @Pip3r4o for helping with this.