### PR TITLE
Improve delivery speed for "now" notifications

### DIFF
--- a/local-notifications.android.js
+++ b/local-notifications.android.js
@@ -167,7 +167,13 @@ LocalNotifications.schedule = function (arg) {
         if (repeatInterval > 0) {
           alarmManager.setRepeating(android.app.AlarmManager.RTC_WAKEUP, options.atTime, repeatInterval, pendingIntent);
         } else {
-          alarmManager.set(android.app.AlarmManager.RTC_WAKEUP, options.atTime, pendingIntent);
+          if (options.at) {
+          	alarmManager.set(android.app.AlarmManager.RTC_WAKEUP, options.atTime, pendingIntent);
+          }
+          else {
+            var notificationManager = context.getSystemService(android.content.Context.NOTIFICATION_SERVICE);
+            notificationManager.notify(options.id, notification);
+          }
         }
 
         LocalNotifications._persist(options);


### PR DESCRIPTION
If the notification is scheduled for `now`, and no repeat `interval` is set, use the `NOTIFICATION_SERVICE` to deliver the notification. This will make sure the notification is shown immediately.

Fixes #55 .

PS: what would be the downside of using `.setExact` on the alarmManager ? As far as I can tell, the `.setRepeating` is already the precise version (as opposed to `.setInexactRepeating`).