### PR TITLE
click action notification nativescriptvue

### DIFF
--- a/local-notifications-common.js
+++ b/local-notifications-common.js
@@ -10,6 +10,11 @@ var LocalNotifications = {
     bigTextStyle: false,
     channel: 'Channel',
     priority: 0, // PRIORITY_HIGH: 1 PRIORITY_LOW: -1 PRIORITY_MAX: 2 PRIORITY_MIN: -2 PRIORITY_DEFAULT: 0
+    intent: {
+      activityClass: com.telerik.localnotifications.NotificationClickedActivity.class,
+      flags: android.content.Intent.FLAG_ACTIVITY_NO_HISTORY,
+      extraName: 'pushBundle'
+    }
   },
   merge: function (obj1, obj2) { // Our merge function
     var result = {}; // return result

--- a/local-notifications.android.js
+++ b/local-notifications.android.js
@@ -132,9 +132,9 @@ LocalNotifications.schedule = function (arg) {
 
         // add the intent that handles the event when the notification is clicked (which should launch the app)
         var reqCode = new java.util.Random().nextInt();
-        var clickIntent = new android.content.Intent(context, com.telerik.localnotifications.NotificationClickedActivity.class)
-            .putExtra("pushBundle", JSON.stringify(options))
-            .setFlags(android.content.Intent.FLAG_ACTIVITY_NO_HISTORY);
+          var clickIntent = new android.content.Intent(context, options.intent.activityClass)
+              .putExtra(options.intent.extraName, JSON.stringify(options))
+              .setFlags(options.intent.flags);
 
         var pendingContentIntent = android.app.PendingIntent.getActivity(context, reqCode, clickIntent, android.app.PendingIntent.FLAG_UPDATE_CURRENT);
         builder.setContentIntent(pendingContentIntent);


### PR DESCRIPTION
This changes are for the correct functionality of the notifications in nativescript-vue.

I'm overriding the creation of Intent in nativescript-vue with:
- The class parameter with com.tns.NativeScriptActivity.class because i have to use the current activity from the manifest, if i don't do this it creates a new empty activity and i lost the data from the notification.
- The flags with android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP in addition to the existing one [There's a better explanation of this here](https://stackoverflow.com/a/1201239/6034526)
- I made the name parameter of putExtra method customizable (i'm maniac xD), so the developers can use their own names.


For nativescript-vue i call the schedule method this way:
```
LocalNotifications.schedule([{
   id: 1,
   title: 'Title',
   body: 'Body',
   ticker: 'The ticker',
   badge: 1,
   groupedMessages:["The first", "Second", "Keep going", "one more..", "OK Stop"], //android only
   groupSummary:"Summary of the grouped messages above", //android only
   channel: 'test', // default: 'Channel'
   name: stringifiedDataJson.name,
   intent: {
      extraName: 'extra',
      flags: android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP | android.content.Intent.FLAG_ACTIVITY_NO_HISTORY,
      activityClass: com.tns.NativeScriptActivity.class
   },
   at: new Date(new Date().getTime() + (2 * 1000)) // 10 seconds from now
}])
```